### PR TITLE
Upgrade add-on base image to 9.1.2

### DIFF
--- a/zerotier/Dockerfile
+++ b/zerotier/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=hassioaddons/base:8.0.6
+ARG BUILD_FROM=ghcr.io/hassio-addons/base/amd64:9.1.0
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
@@ -13,12 +13,12 @@ COPY rootfs/patches /patches
 RUN \
     apk add --no-cache --virtual .build-dependencies \
         build-base=0.5-r2 \
-        linux-headers=5.4.5-r1 \
-        git=2.26.2-r0 \
+        linux-headers=5.7.8-r0 \
+        git=2.30.0-r0 \
     \
     && apk add --no-cache \
-        libgcc=9.3.0-r2 \
-        libstdc++=9.3.0-r2 \
+        libgcc=10.2.1_pre1-r3 \
+        libstdc++=10.2.1_pre1-r3 \
     \
     && git clone --branch "1.4.6" --depth=1 \
         "https://github.com/zerotier/ZeroTierOne.git" /tmp/zerotier \

--- a/zerotier/Dockerfile
+++ b/zerotier/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/base/amd64:9.1.0
+ARG BUILD_FROM=ghcr.io/hassio-addons/base/amd64:9.1.2
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 

--- a/zerotier/build.json
+++ b/zerotier/build.json
@@ -1,9 +1,9 @@
 {
   "build_from": {
-    "aarch64": "hassioaddons/base-aarch64:8.0.6",
-    "amd64": "hassioaddons/base-amd64:8.0.6",
-    "armhf": "hassioaddons/base-armhf:8.0.6",
-    "armv7": "hassioaddons/base-armv7:8.0.6",
-    "i386": "hassioaddons/base-i386:8.0.6"
+    "aarch64": "ghcr.io/hassio-addons/base/aarch64:9.1.0",
+    "amd64": "ghcr.io/hassio-addons/base/amd64:9.1.0",
+    "armhf": "ghcr.io/hassio-addons/base/armhf:9.1.0",
+    "armv7": "ghcr.io/hassio-addons/base/armv7:9.1.0",
+    "i386": "ghcr.io/hassio-addons/base/i386:9.1.0"
   }
 }

--- a/zerotier/build.json
+++ b/zerotier/build.json
@@ -1,9 +1,9 @@
 {
   "build_from": {
-    "aarch64": "ghcr.io/hassio-addons/base/aarch64:9.1.0",
-    "amd64": "ghcr.io/hassio-addons/base/amd64:9.1.0",
-    "armhf": "ghcr.io/hassio-addons/base/armhf:9.1.0",
-    "armv7": "ghcr.io/hassio-addons/base/armv7:9.1.0",
-    "i386": "ghcr.io/hassio-addons/base/i386:9.1.0"
+    "aarch64": "ghcr.io/hassio-addons/base/aarch64:9.1.2",
+    "amd64": "ghcr.io/hassio-addons/base/amd64:9.1.2",
+    "armhf": "ghcr.io/hassio-addons/base/armhf:9.1.2",
+    "armv7": "ghcr.io/hassio-addons/base/armv7:9.1.2",
+    "i386": "ghcr.io/hassio-addons/base/i386:9.1.2"
   }
 }

--- a/zerotier/config.json
+++ b/zerotier/config.json
@@ -13,7 +13,6 @@
   "ports_description": {
     "9993/tcp": "ZeroTier's primary port"
   },
-  "hassio_api": true,
   "host_network": true,
   "privileged": ["NET_ADMIN", "SYS_ADMIN"],
   "devices": ["/dev/net/tun:/dev/net/tun:rwm"],


### PR DESCRIPTION
# Proposed Changes

Upgrade base image to the latest version, allowing to remove Supervisor API access.
