### PR TITLE
Fix unaccepted network str

### DIFF
--- a/zerotier/config.yaml
+++ b/zerotier/config.yaml
@@ -28,6 +28,6 @@ options:
   api_auth_token: ""
 schema:
   networks:
-    - match(^!secret [a-zA-Z0-9_\-]+$|[0-9a-z]{16})
+    - str
   api_auth_token: str
   log_level: list(trace|debug|info|notice|warning|error|fatal)?


### PR DESCRIPTION
# Proposed Changes

Remove the strict check. The application already checks it, so let's just remove the format check from the add-on

## Related Issues

fixes #271

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the validation for network entries, allowing any string value for network configuration instead of restricting to specific formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->