### PR TITLE
⬆️ Update to base image v21.0.0 and Alpine 3.24

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,7 +26,7 @@
       ],
       "versioningTemplate": "loose",
       "datasourceTemplate": "repology",
-      "depNameTemplate": "alpine_3_23/{{package}}"
+      "depNameTemplate": "alpine_3_24/{{package}}"
     },
     {
       "customType": "regex",

--- a/zerotier/Dockerfile
+++ b/zerotier/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/base:20.1.1
+ARG BUILD_FROM=ghcr.io/hassio-addons/base:21.0.0
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
@@ -10,16 +10,16 @@ ARG ZERO_TIER_ONE_VERSION="1.16.2"
 # hadolint ignore=DL3003
 RUN \
     apk add --no-cache --virtual .build-dependencies \
-        build-base=0.5-r3 \
-        cargo=1.91.1-r2 \
-        git=2.52.0-r0 \
-        linux-headers=6.16.12-r0 \
-        openssl-dev=3.5.6-r0 \
+        build-base=0.5-r4 \
+        cargo=1.96.0-r0 \
+        git=2.54.0-r0 \
+        linux-headers=7.0.0-r1 \
+        openssl-dev=3.5.7-r0 \
         pkgconf=2.5.1-r0 \
     \
     && apk add --no-cache \
-        libgcc=15.2.0-r2 \
-        libstdc++=15.2.0-r2 \
+        libgcc=15.2.0-r5 \
+        libstdc++=15.2.0-r5 \
     \
     && git clone --branch "${ZERO_TIER_ONE_VERSION}" --depth=1 \
         "https://github.com/zerotier/ZeroTierOne.git" /tmp/zerotier \

--- a/zerotier/build.yaml
+++ b/zerotier/build.yaml
@@ -1,4 +1,4 @@
 ---
 build_from:
-  aarch64: ghcr.io/hassio-addons/base:20.1.1
-  amd64: ghcr.io/hassio-addons/base:20.1.1
+  aarch64: ghcr.io/hassio-addons/base:21.0.0
+  amd64: ghcr.io/hassio-addons/base:21.0.0


### PR DESCRIPTION
# Proposed Changes

This updates the add-on to the latest Home Assistant add-on base image v21.0.0, which is based on Alpine Linux 3.24.0, and bumps all pinned Alpine packages to their latest versions for that release.

Changes:
- Base image `ghcr.io/hassio-addons/base`: `20.1.1` → `21.0.0` (Alpine `3.24.0`)
- `build-base`: `0.5-r3` → `0.5-r4`
- `cargo`: `1.91.1-r2` → `1.96.0-r0` (moved from the community to the main repository in Alpine 3.24)
- `git`: `2.52.0-r0` → `2.54.0-r0`
- `linux-headers`: `6.16.12-r0` → `7.0.0-r1`
- `openssl-dev`: `3.5.6-r0` → `3.5.7-r0`
- `libgcc`: `15.2.0-r2` → `15.2.0-r5`
- `libstdc++`: `15.2.0-r2` → `15.2.0-r5`
- Renovate Repology tracking: `alpine_3_23` → `alpine_3_24`

The image builds successfully with `docker build . --progress=plain --no-cache`.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated base image version to 21.0.0.
  * Updated build stage dependency packages to newer versions.
  * Updated dependency management configuration for Alpine package resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->