### PR TITLE
🐛 Apply the configured log_level option

### DIFF
--- a/zerotier/rootfs/etc/s6-overlay/s6-rc.d/init-zerotier/run
+++ b/zerotier/rootfs/etc/s6-overlay/s6-rc.d/init-zerotier/run
@@ -10,6 +10,9 @@ declare network
 declare node
 declare token
 
+# Set the log level based on the add-on configuration
+bashio::log.level "$(bashio::config 'log_level' 'info')"
+
 # Generate identity if it does not exist
 if ! bashio::fs.file_exists "${private}" \
     || ! bashio::fs.file_exists "${public}";


### PR DESCRIPTION
The `log_level` option was defined in the add-on schema and documented in `DOCS.md`, but it was never applied at runtime. Nothing called `bashio::log.level`, so setting `log_level` (e.g. to `debug`) had no effect on the actual log verbosity.

This wires the option up at the start of the init service so the configured level is honored, defaulting to `info` when unset.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Log verbosity levels are now configurable through add-on settings, enabling users to control logging detail at startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->