### PR TITLE
🐛 Harden API auth token file handling

### DIFF
--- a/zerotier/rootfs/etc/s6-overlay/s6-rc.d/init-zerotier/run
+++ b/zerotier/rootfs/etc/s6-overlay/s6-rc.d/init-zerotier/run
@@ -43,7 +43,8 @@ bashio::log.info "ZeroTier node address: ${node}"
 # Sets the auth token for the local JSON API
 if bashio::config.has_value 'api_auth_token'; then
     token=$(bashio::config 'api_auth_token')
-    echo "${token}" > /var/lib/zerotier-one/authtoken.secret
+    printf '%s' "${token}" > /var/lib/zerotier-one/authtoken.secret
+    chmod 600 /var/lib/zerotier-one/authtoken.secret
 fi
 
 # Ensure network folder exists


### PR DESCRIPTION
Two issues with how the local JSON API auth token is written to `authtoken.secret`:

- It was written with `echo`, which appends a trailing newline. Depending on the client, ZeroTier compares the token verbatim, so a trailing newline can cause authentication to fail. This switches to `printf '%s'` so the file contains exactly the configured token.
- The file was created with default (world-readable) permissions, exposing the API token to anything else that can read the filesystem. ZeroTier itself writes this file as `0600`; this now does the same with an explicit `chmod 600`.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced authentication credential handling with proper file permission settings during system initialization.
  * Improved token storage security by enforcing restricted file access controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->