### PR TITLE
🧹 Fix comment typos and remove dead variable

### DIFF
--- a/zerotier/rootfs/etc/s6-overlay/s6-rc.d/init-zerotier/run
+++ b/zerotier/rootfs/etc/s6-overlay/s6-rc.d/init-zerotier/run
@@ -2,7 +2,7 @@
 # shellcheck shell=bash
 # ==============================================================================
 # Home Assistant Community App: ZeroTier One
-# Generates an identiy in case it does not exists yet
+# Generates an identity in case it does not exist yet
 # ==============================================================================
 readonly private='/ssl/zerotier/identity.secret'
 readonly public='/ssl/zerotier/identity.public'
@@ -18,12 +18,12 @@ then
 
     if bashio::fs.file_exists "${private}"; then
         rm -f "${private}" \
-            || bashio::exit.nok "Failed to delete old private identify file"
+            || bashio::exit.nok "Failed to delete old private identity file"
     fi
 
     if bashio::fs.file_exists "${public}"; then
         rm -f "${public}" \
-            || bashio::exit.nok "Failed to delete old private identify file"
+            || bashio::exit.nok "Failed to delete old public identity file"
     fi
 
     if ! bashio::fs.directory_exists '/ssl/zerotier'; then
@@ -50,7 +50,7 @@ fi
 mkdir -p "/var/lib/zerotier-one/networks.d" \
     || bashio::exit.nok "Could not create networks folder"
 
-# Install user configured/requested packages
+# Configure the user requested networks
 if bashio::config.has_value 'networks'; then
     while read -r network; do
         bashio::log.info "Configuring network: ${network}"

--- a/zerotier/rootfs/etc/s6-overlay/s6-rc.d/zerotier/finish
+++ b/zerotier/rootfs/etc/s6-overlay/s6-rc.d/zerotier/finish
@@ -4,7 +4,6 @@
 # Home Assistant Community App: ZeroTier One
 # Take down the S6 supervision tree when ZeroTier fails
 # ==============================================================================
-declare exit_code
 readonly exit_code_container=$(</run/s6-linux-init-container-results/exitcode)
 readonly exit_code_service="${1}"
 readonly exit_code_signal="${2}"

--- a/zerotier/rootfs/etc/s6-overlay/s6-rc.d/zerotier/run
+++ b/zerotier/rootfs/etc/s6-overlay/s6-rc.d/zerotier/run
@@ -8,7 +8,7 @@ declare -a options
 
 bashio::log.info "Starting ZeroTier One..."
 
-# Note sure what this does.
+# Skip the privilege check and do not attempt to drop privileges
 options+=(-U)
 options+=("-p$(bashio::app.port 9993)")
 


### PR DESCRIPTION
Small, no-behavior-change cleanups in the service scripts:

- Fix typos in the init service comments and error messages ("identiy" → "identity", "does not exists" → "does not exist", "identify file" → "identity file").
- Correct the error message when deleting the old public identity file, which incorrectly said "private".
- Replace the misleading "Install user configured/requested packages" comment (copy-paste leftover) with one that describes configuring the requested networks.
- Replace the "Note sure what this does." comment with a description of the `zerotier-one -U` flag (skip the privilege check and do not attempt to drop privileges).
- Remove an unused `exit_code` variable declaration in the finish script.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/