### PR TITLE
👷 Replace Repology with Alpine CDN datasource for package pins

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,12 @@
   "labels": ["dependencies", "no-stale"],
   "commitMessagePrefix": "⬆️",
   "commitMessageTopic": "{{depName}}",
+  "customDatasources": {
+    "alpine": {
+      "defaultRegistryUrlTemplate": "https://dl-cdn.alpinelinux.org/alpine/v3.24/main/x86_64/",
+      "format": "html"
+    }
+  },
   "customManagers": [
     {
       "customType": "regex",
@@ -25,8 +31,9 @@
         "\\s\\s(?<package>[a-z0-9-]+)=(?<currentValue>[a-z0-9-_.]+)\\s+"
       ],
       "versioningTemplate": "loose",
-      "datasourceTemplate": "repology",
-      "depNameTemplate": "alpine_3_24/{{package}}"
+      "datasourceTemplate": "custom.alpine",
+      "depNameTemplate": "alpine_3_24/{{package}}",
+      "extractVersionTemplate": "^{{{package}}}-(?<version>\\d.*)\\.apk$"
     },
     {
       "customType": "regex",
@@ -40,7 +47,7 @@
   ],
   "packageRules": [
     {
-      "matchDatasources": ["repology"],
+      "matchDatasources": ["custom.alpine"],
       "automerge": true
     },
     {

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -28,12 +28,12 @@
       "managerFilePatterns": ["//Dockerfile$/"],
       "matchStringsStrategy": "any",
       "matchStrings": [
-        "\\s\\s(?<package>[a-z0-9-]+)=(?<currentValue>[a-z0-9-_.]+)\\s+"
+        "\\s\\s(?<package>[a-z0-9][a-z0-9._+-]*)=(?<currentValue>[a-z0-9-_.]+)\\s+"
       ],
       "versioningTemplate": "loose",
       "datasourceTemplate": "custom.alpine",
       "depNameTemplate": "alpine_3_24/{{package}}",
-      "extractVersionTemplate": "^{{{package}}}-(?<version>\\d.*)\\.apk$"
+      "extractVersionTemplate": "^{{{replace '\\.' '\\.' (replace '\\+' '%2B' package)}}}-(?<version>\\d.*)\\.apk$"
     },
     {
       "customType": "regex",


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Renovate's `repology` datasource has stopped resolving Alpine package pins across the org. Every `alpine_3_24/*` lookup returns `no-result`, so Alpine pins are no longer updated at all and builds break whenever upstream moves a pinned package. Repology rate limits its `tools/project-by` endpoint hard, and each run resolves every pin through it.

This applies the same fix already landed on `app-ssh` (hassio-addons/app-ssh#1119) to this repository:

- Adds a `custom.alpine` datasource that reads the Alpine CDN directory listing (`https://dl-cdn.alpinelinux.org/alpine/v3.24/main/x86_64/`) with Renovate's `html` format.
- Switches the Alpine custom manager from `repology` to `custom.alpine`, and adds `extractVersionTemplate` to pull the version out of each `.apk` filename. The leading `\d` in that regex matters: it stops `nano` from matching `nano-syntax-...`.
- Switches the one `matchDatasources: ["repology"]` package rule over to `custom.alpine`.

No `registryUrls` override rule for the Alpine `community` repository is included, because this app does not need one: all eight packages pinned in `zerotier/Dockerfile` (`build-base`, `cargo`, `git`, `libgcc`, `libstdc++`, `linux-headers`, `openssl-dev`, `pkgconf`) live in Alpine `main`. This was derived mechanically from the `v3.24` `main` and `community` `APKINDEX` files rather than copied from `app-ssh`.

## Verification

A passing CI build proves nothing here: the config change does not touch the Dockerfile, so buildx serves the `apk` layer from cache and no `apk add` runs. Verified locally instead:

- `renovate-config-validator .github/renovate.json` passes.
- A local dry-run lookup (`RENOVATE_PLATFORM=local RENOVATE_DRY_RUN=lookup`) resolves **all 8 `custom.alpine` dependencies with 0 lookup failures** (no `Found no results`, no `no-result`, no empty release sets).
- It reports **no Alpine updates**, which cross-checks correctly against the `main` `APKINDEX`: all eight pins are already at the current upstream version, so there are no stale pins blocking anything in this repo. The only update the dry-run finds is the unrelated base image bump (`21.0.1` -> `21.0.2`).
- As a negative control, temporarily downgrading the `libstdc++` pin to `15.1.0-r0` makes the dry-run correctly propose `15.2.0-r5`, confirming the chain works end to end rather than failing quietly.

## Package names containing regex metacharacters

The manager's original capture pattern was `[a-z0-9-]+`, which silently excluded `libstdc++`, so that pin was extracted by neither the old Repology config nor the first commit here. The second commit widens the class and escapes the captured name before it reaches `extractVersionTemplate`, which is needed because `libstdc++` interpolated raw compiles to an invalid regex (`c++` is a nested quantifier).

Two details worth recording:

- The `+` is replaced with `%2B`, not with an escaped `\+`. Escaping alone produces a valid regex but still resolves zero releases, because the Alpine CDN percent-encodes it in the directory listing (`href="libstdc%2B%2B-15.2.0-r5.apk"`) and Renovate matches against the raw href.
- `.` is escaped through a nested `replace`, so a name like `lua5.4` cannot match a stray character. Nothing pinned here needs that today; it just keeps the template honest.

`app-ssh` uses `[a-z0-9][a-z0-9-_]+` and so has the same gap, should a `+`-containing package ever be pinned there.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Applies the same change as hassio-addons/app-ssh#1119.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Alpine package detection to support a broader range of package names.
  * Increased the reliability of Alpine package version identification using the Alpine v3.24 package registry.
  * Updated automated update handling so supported Alpine packages are processed consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->